### PR TITLE
Simplify duplicated code and add moveMotorStep

### DIFF
--- a/pytapo/__init__.py
+++ b/pytapo/__init__.py
@@ -78,7 +78,7 @@ class Tapo:
         except Exception as e:
             raise Exception("Unexpected response from Tapo Camera: " + str(e))
 
-    def performRequest(self, inData, loginRetryCountdown=5):
+    def performRequest(self, inData, loginRetryCountdown=1):
         self.ensureAuthenticated()
         url = self.getHostURL()
         res = requests.post(

--- a/pytapo/__init__.py
+++ b/pytapo/__init__.py
@@ -243,6 +243,9 @@ class Tapo:
         })
 
     def moveMotorStep(self, angle):
+        if not (0 <= angle < 360):
+            raise Exception("Angle must be in a range 0 <= angle < 360")
+
         return self.performRequest({
             "method": "do",
             "motor": {"movestep": {"direction": str(angle)}},

--- a/pytapo/__init__.py
+++ b/pytapo/__init__.py
@@ -2,10 +2,12 @@
 # Author: Juraj Nyiri
 #
 
-import requests
 import hashlib
 import json
+
+import requests
 import urllib3
+
 from .const import ERROR_CODES, DEVICES_WITH_NO_PRESETS
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -31,8 +33,8 @@ class Tapo:
 
         self.basicInfo = self.getBasicInfo()
         if (
-            self.basicInfo["device_info"]["basic_info"]["device_model"]
-            in DEVICES_WITH_NO_PRESETS
+                self.basicInfo["device_info"]["basic_info"]["device_model"]
+                in DEVICES_WITH_NO_PRESETS
         ):
             self.presets = {}
         else:
@@ -102,36 +104,36 @@ class Tapo:
                 return self.getOsd(True)
 
     def setOsd(
-        self,
-        label,
-        dateEnabled=True,
-        labelEnabled=False,
-        weekEnabled=False,
-        dateX=0,
-        dateY=0,
-        labelX=0,
-        labelY=500,
-        weekX=0,
-        weekY=0,
-        raiseException=False,
+            self,
+            label,
+            dateEnabled=True,
+            labelEnabled=False,
+            weekEnabled=False,
+            dateX=0,
+            dateY=0,
+            labelX=0,
+            labelY=500,
+            weekX=0,
+            weekY=0,
+            raiseException=False,
     ):
         if len(label) >= 16:
             raise Exception("Error: Label cannot be longer than 16 characters.")
         elif len(label) == 0:
             labelEnabled = False
         if (
-            dateX > 10000
-            or dateX < 0
-            or labelX > 10000
-            or labelX < 0
-            or weekX > 10000
-            or weekX < 0
-            or dateY > 10000
-            or dateY < 0
-            or labelY > 10000
-            or labelY < 0
-            or weekY > 10000
-            or weekY < 0
+                dateX > 10000
+                or dateX < 0
+                or labelX > 10000
+                or labelX < 0
+                or weekX > 10000
+                or weekX < 0
+                or dateY > 10000
+                or dateY < 0
+                or labelY > 10000
+                or labelY < 0
+                or weekY > 10000
+                or weekY < 0
         ):
             raise Exception(
                 "Error: Incorrect corrdinates, must be between 0 and 10000."
@@ -467,7 +469,7 @@ class Tapo:
                 return self.setPrivacyMode(enabled, True)
 
     def setAlarm(
-        self, enabled, soundEnabled=True, lightEnabled=True, raiseException=False
+            self, enabled, soundEnabled=True, lightEnabled=True, raiseException=False
     ):
         self.ensureAuthenticated()
         url = self.getHostURL()
@@ -533,6 +535,31 @@ class Tapo:
             else:
                 self.refreshStok()
                 return self.moveMotor(x, y, True)
+
+    def moveMotorStep(self, angle, raiseException=False):
+        self.ensureAuthenticated()
+        url = self.getHostURL()
+        data = {
+            "method": "do",
+            "motor": {"movestep": {"direction": str(angle)}},
+        }
+        res = requests.post(
+            url, data=json.dumps(data), headers=self.headers, verify=False
+        )
+        data = json.loads(res.text)
+        if self.responseIsOK(res):
+            return True
+        else:
+            if raiseException:
+                raise Exception(
+                    "Error: "
+                    + self.getErrorMessage(data["error_code"])
+                    + " Response:"
+                    + json.dumps(data)
+                )
+            else:
+                self.refreshStok()
+                return self.moveMotorStep(angle, True)
 
     def format(self, raiseException=False):
         self.ensureAuthenticated()

--- a/pytapo/__init__.py
+++ b/pytapo/__init__.py
@@ -21,7 +21,7 @@ class Tapo:
         self.stok = False
         self.headers = {
             "Host": self.host,
-            "Referer": "https://" + self.host + ":443",
+            "Referer": "https://{host}".format(host=self.host),
             "Accept": "application/json",
             "Accept-Encoding": "gzip, deflate",
             "User-Agent": "Tapo CameraClient Android",
@@ -41,7 +41,7 @@ class Tapo:
             self.presets = self.getPresets()
 
     def getHostURL(self):
-        return "https://" + self.host + ":443" + "/stok=" + self.stok + "/ds"
+        return "https://{host}/stok={stok}/ds".format(host=self.host, stok=self.stok)
 
     def ensureAuthenticated(self):
         if not self.stok:
@@ -49,7 +49,7 @@ class Tapo:
         return True
 
     def refreshStok(self):
-        url = "https://" + self.host + ":443"
+        url = "https://{host}".format(host=self.host)
         data = {
             "method": "login",
             "params": {
@@ -116,7 +116,6 @@ class Tapo:
             labelY=500,
             weekX=0,
             weekY=0,
-            raiseException=False,
     ):
         if len(label) >= 16:
             raise Exception("Error: Label cannot be longer than 16 characters.")


### PR DESCRIPTION
If you prefer the new movement method and the de-duplication as separate pull requests, let me know. It's simpler for me to send everything in one batch, though :)

This pull request, other than adding `motorMoveStep` which moves the motor in a direction, removes all the duplicated request handling code and puts it into a common helper method.

The URL generation was rewritten using `str.format`. Also I removed `:443` since 443 is the standard HTTPS port.

I removed the `raiseException` parameter: it is only useful if the session token has expired, so I moved that part in the common `performRequest` method and the token is refreshed only if the camera returned a stok error (otherwise an exception is always thrown).