### PR TITLE
Add motor calibration

### DIFF
--- a/pytapo/__init__.py
+++ b/pytapo/__init__.py
@@ -295,6 +295,9 @@ class Tapo:
             }
         )
 
+    def calibrateMotor(self):
+        return self.performRequest({"method": "do", "motor": {"manual_cali": ""}})
+
     def format(self):
         return self.performRequest(
             {"method": "do", "harddisk_manage": {"format_hd": "1"}}

--- a/test_pytapo.py
+++ b/test_pytapo.py
@@ -479,6 +479,11 @@ def test_moveMotorStep():
     assert result2["error_code"] == 0
 
 
+def test_calibrateMotor():
+    tapo = Tapo(host, user, password)
+    tapo.calibrateMotor()
+
+
 def test_setLEDEnabled():
     tapo = Tapo(host, user, password)
     origLedEnabled = tapo.getLED()["enabled"] == "on"


### PR DESCRIPTION
The command moves the camera all the way to the endstops, then recenters it.

It is required for accurate PTZ control if the camera has been manually rotated, since it uses "dumb" DC motors