### PR TITLE
Add force white lamp state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ pytapo.egg-info
 htmlcov
 .coverage
 output
+.DS_Store

--- a/test_pytapo.py
+++ b/test_pytapo.py
@@ -496,40 +496,32 @@ def test_setLEDEnabled():
     assert (result["enabled"] == "on") == origLedEnabled
 
 
-def test_getCommonImage():
-    tapo = Tapo(host, user, password)
-    result = tapo.getCommonImage()
-    assert result["error_code"] == 0
-    assert "image" in result
-    assert "common" in result["image"]
-
-
 def test_setDayNightMode():
     tapo = Tapo(host, user, password)
-    origDayNightMode = tapo.getCommonImage()["image"]["common"]["inf_type"]
+    origDayNightMode = tapo.getDayNightMode()
     result = tapo.setDayNightMode("off")
     assert result["error_code"] == 0
-    dayNightMode = tapo.getCommonImage()["image"]["common"]["inf_type"]
+    dayNightMode = tapo.getDayNightMode()
     assert dayNightMode == "off"
     result = tapo.setDayNightMode("on")
     assert result["error_code"] == 0
-    dayNightMode = tapo.getCommonImage()["image"]["common"]["inf_type"]
+    dayNightMode = tapo.getDayNightMode()
     assert dayNightMode == "on"
     result = tapo.setDayNightMode("auto")
     assert result["error_code"] == 0
-    dayNightMode = tapo.getCommonImage()["image"]["common"]["inf_type"]
+    dayNightMode = tapo.getDayNightMode()
     assert dayNightMode == "auto"
     result = tapo.setDayNightMode("off")
     assert result["error_code"] == 0
-    dayNightMode = tapo.getCommonImage()["image"]["common"]["inf_type"]
+    dayNightMode = tapo.getDayNightMode()
     assert dayNightMode == "off"
     result = tapo.setDayNightMode(origDayNightMode)
     assert result["error_code"] == 0
-    dayNightMode = tapo.getCommonImage()["image"]["common"]["inf_type"]
+    dayNightMode = tapo.getDayNightMode()
     assert dayNightMode == origDayNightMode
     with pytest.raises(Exception) as err:
         tapo.setDayNightMode("unsupported")
-    assert "Invalid inf_type, can be off, on or auto" in str(err.value)
+    assert "Day night mode must be one of ['off', 'on', 'auto']" in str(err.value)
 
 
 def test_setMotionDetection():
@@ -649,6 +641,20 @@ def test_imageFlipVertical():
     assert tapo.getImageFlipVertical() == origImageFlipVertical
 
 
+def test_forceWhiteLampState():
+    tapo = Tapo(host, user, password)
+    origForceWhiteLampState = tapo.getForceWhitelampState()
+
+    tapo.setForceWhitelampState(True)
+    assert tapo.getForceWhitelampState()
+
+    tapo.setForceWhitelampState(False)
+    assert not tapo.getForceWhitelampState()
+
+    tapo.setForceWhitelampState(origForceWhiteLampState)
+    assert tapo.getForceWhitelampState() == origForceWhiteLampState
+
+
 def test_lensDistortionCorrection():
     tapo = Tapo(host, user, password)
     origLensDistortionCorrection = tapo.getLensDistortionCorrection()
@@ -691,26 +697,23 @@ def test_getRecordings():
 
 def test_lightFrequencyMode():
     tapo = Tapo(host, user, password)
-    origLightFrequency = tapo.getCommonImage()["image"]["common"]["light_freq_mode"]
+    origLightFrequency = tapo.getLightFrequencyMode()
 
     tapo.setLightFrequencyMode("50")
-    assert tapo.getCommonImage()["image"]["common"]["light_freq_mode"] == "50"
+    assert tapo.getLightFrequencyMode()
 
     tapo.setLightFrequencyMode("60")
-    assert tapo.getCommonImage()["image"]["common"]["light_freq_mode"] == "60"
+    assert tapo.getLightFrequencyMode()
 
     tapo.setLightFrequencyMode("auto")
-    assert tapo.getCommonImage()["image"]["common"]["light_freq_mode"] == "auto"
+    assert tapo.getLightFrequencyMode()
 
     with pytest.raises(Exception) as err:
         tapo.setLightFrequencyMode("invalid")
     assert "Light frequency mode must be one of" in str(err.value)
 
     tapo.setLightFrequencyMode(origLightFrequency)
-    assert (
-        tapo.getCommonImage()["image"]["common"]["light_freq_mode"]
-        == origLightFrequency
-    )
+    assert tapo.getLightFrequencyMode() == origLightFrequency
 
 
 def test_calibrateMotor():


### PR DESCRIPTION
# Context
The [Tapo C320WS](https://www.tp-link.com/au/home-networking/cloud-camera/tapo-c320ws/) supports a floodlight, referred to in the API as a "Whitelamp". This PR adds support for turning this on and off.

The PR also includes a refactor to simplify how "common' and "switch" values are set/get, and adds some abstractions so library consumers don't need to unpack response data.

# Additions
- Add `getForceWhitelampState` and `setForceWhitelampState` for getting and setting floodlight status
- Sync private `__getImageSwitch` / `__setImageSwitch` and `__getImageCommon` / `__setImageCommon` functionality
- Add `getLightFrequencyMode` and `getDayNightMode` to avoid depending on API implementation details
- Revise `setDayNightMode` to be consistent with `setLightFrequencyMode`

# Caveats
Some of the existing tests don't work with the C320WS, for example, due to the lack of a motor. Logging the failures here for future investigation, we might want to keep track of individual camera model capabilities, or simply bail on tests that return a `-40106`.
```
FAILED test_pytapo.py::test_getMotionDetection - AssertionError: assert 'enhanced' in {'.name': 'motion_det', '.type': 'on_off', 'digital_sensitivity': '50', 'enabled': 'on', ...}
FAILED test_pytapo.py::test_getAutoTrackTarget - Exception: Error: Parameter to get/do does not exist Response:{"target_track": {}, "error_code": -40106}
FAILED test_pytapo.py::test_getMotorCapability - Exception: Error: Parameter to get/do does not exist Response:{"motor": {}, "error_code": -40106}
FAILED test_pytapo.py::test_moveMotor - Exception: Error: Parameter to get/do does not exist Response:{"error_code": -40106}
FAILED test_pytapo.py::test_moveMotorStep - Exception: Error: Parameter to get/do does not exist Response:{"error_code": -40106}
FAILED test_pytapo.py::test_setAutoTrackTarget - Exception: Error: Parameter to get/do does not exist Response:{"target_track": {}, "error_code": -40106}
FAILED test_pytapo.py::test_errorMessage - assert 'Privacy mode is ON, not able to execute' in 'Error: Parameter to get/do does not exist Response:{"error_code": -40106}'
FAILED test_pytapo.py::test_preset - Exception: Error: Parameter to get/do does not exist Response:{"error_code": -40106}
FAILED test_pytapo.py::test_getRecordings - KeyError: 'playback'
FAILED test_pytapo.py::test_calibrateMotor - Exception: Error: Parameter to get/do does not exist Response:{"error_code": -40106}
```
