### PR TITLE
Add startManualAlarm and stopManualAlarm

### DIFF
--- a/pytapo/__init__.py
+++ b/pytapo/__init__.py
@@ -454,6 +454,22 @@ class Tapo:
             {"method": "set", "image": {"common": {"light_freq_mode": mode}}}
         )
 
+    def startManualAlarm(self):
+        return self.performRequest(
+            {
+                "method": "do",
+                "msg_alarm": {"manual_msg_alarm": {"action": "start"}},
+            }
+        )
+
+    def stopManualAlarm(self):
+        return self.performRequest(
+            {
+                "method": "do",
+                "msg_alarm": {"manual_msg_alarm": {"action": "stop"}},
+            }
+        )
+
     @staticmethod
     def getErrorMessage(errorCode):
         if str(errorCode) in ERROR_CODES:

--- a/test_pytapo.py
+++ b/test_pytapo.py
@@ -718,6 +718,14 @@ def test_calibrateMotor():
     tapo.calibrateMotor()
 
 
+def test_startStopManualAlarm():
+    tapo = Tapo(host, user, password)
+    result = tapo.startManualAlarm()
+    assert result["error_code"] == 0
+    result = tapo.startManualAlarm()
+    assert result["error_code"] == 0
+
+
 def test_reboot():
     tapo = Tapo(host, user, password)
     result = tapo.reboot()

--- a/test_pytapo.py
+++ b/test_pytapo.py
@@ -722,7 +722,7 @@ def test_startStopManualAlarm():
     tapo = Tapo(host, user, password)
     result = tapo.startManualAlarm()
     assert result["error_code"] == 0
-    result = tapo.startManualAlarm()
+    result = tapo.stopManualAlarm()
     assert result["error_code"] == 0
 
 


### PR DESCRIPTION
Add startManualAlarm and stopManualAlarm to manually start the alarm sound and light,
Tested on tapo C100
Based on  https://github.com/ttimasdf/mercury-ipc-control examples