### PR TITLE
Feature: Person detection

### DIFF
--- a/pytapo/__init__.py
+++ b/pytapo/__init__.py
@@ -212,6 +212,10 @@ class Tapo:
         data = {"method": "get", "motion_detection": {"name": ["motion_det"]}}
         return self.performRequest(data)["motion_detection"]["motion_det"]
 
+    def getPersonDetection(self):
+        data = {"method": "get", "people_detection": {"name": ["detection"]}}
+        return self.performRequest(data)["people_detection"]["detection"]
+
     def getAlarm(self):
         data = {"method": "get", "msg_alarm": {"name": ["chn1_msg_alarm_info"]}}
         return self.performRequest(data)["msg_alarm"]["chn1_msg_alarm_info"]
@@ -398,6 +402,23 @@ class Tapo:
 
         return self.performRequest(data)
 
+    def setPersonDetection(self, enabled, sensitivity=False):
+        data = {
+            "method": "set",
+            "people_detection": {"detection": {"enabled": "on" if enabled else "off"}},
+        }
+        if sensitivity:
+            if sensitivity == "high":
+                data["people_detection"]["detection"]["sensitivity"] = "80"
+            elif sensitivity == "normal":
+                data["people_detection"]["detection"]["sensitivity"] = "50"
+            elif sensitivity == "low":
+                data["people_detection"]["detection"]["sensitivity"] = "20"
+            else:
+                raise Exception("Invalid sensitivity, can be low, normal or high")
+
+        return self.performRequest(data)
+
     def setAutoTrackTarget(self, enabled):
         return self.performRequest(
             {
@@ -576,6 +597,10 @@ class Tapo:
                         {
                             "method": "getDetectionConfig",
                             "params": {"motion_detection": {"name": ["motion_det"]}},
+                        },
+                        {
+                            "method": "getPersonDetectionConfig",
+                            "params": {"people_detection": {"name": ["detection"]}},
                         },
                         {
                             "method": "getLensMaskConfig",

--- a/test_pytapo.py
+++ b/test_pytapo.py
@@ -334,6 +334,15 @@ def test_getMotionDetection():
     assert "digital_sensitivity" in result
 
 
+def test_getPersonDetection():
+    tapo = Tapo(host, user, password)
+    result = tapo.getPersonDetection()
+    assert result[".name"] == "detection"
+    assert result[".type"] == "on_off"
+    assert "enabled" in result
+    assert "sensitivity" in result
+
+
 def test_getAlarm():
     tapo = Tapo(host, user, password)
     result = tapo.getAlarm()
@@ -620,6 +629,44 @@ def test_setMotionDetection():
     result = tapo.getMotionDetection()
     assert result["enabled"] == origMotionDetection["enabled"]
     assert result["sensitivity"] == origMotionDetection["sensitivity"]
+
+
+def test_setPersonDetection():
+    tapo = Tapo(host, user, password)
+    origPersonDetection = tapo.getPersonDetection()
+    origPersonDetectionSensitivity = origPersonDetection["sensitivity"]
+    if origPersonDetectionSensitivity == "medium":
+        origPersonDetectionSensitivity = "normal"
+
+    tapo.setPersonDetection(False)
+    result = tapo.getPersonDetection()
+    assert result["enabled"] == "off"
+    tapo.setPersonDetection(True)
+    result = tapo.getPersonDetection()
+    assert result["enabled"] == "on"
+    tapo.setPersonDetection(False)
+    result = tapo.getPersonDetection()
+    assert result["enabled"] == "off"
+    tapo.setPersonDetection(False, "low")
+    result = tapo.getPersonDetection()
+    assert result["sensitivity"] == "low"
+    tapo.setPersonDetection(False, "normal")
+    result = tapo.getPersonDetection()
+    assert result["sensitivity"] == "medium"
+    tapo.setPersonDetection(False, "high")
+    result = tapo.getPersonDetection()
+    assert result["sensitivity"] == "high"
+
+    with pytest.raises(Exception) as err:
+        tapo.setPersonDetection(False, "unsupported")
+    assert "Invalid sensitivity, can be low, normal or high" in str(err.value)
+
+    tapo.setPersonDetection(
+        origPersonDetection["enabled"] == "on", origPersonDetectionSensitivity
+    )
+    result = tapo.getPersonDetection()
+    assert result["enabled"] == origPersonDetection["enabled"]
+    assert result["sensitivity"] == origPersonDetection["sensitivity"]
 
 
 def test_setAutoTrackTarget():


### PR DESCRIPTION
Added methods for getting and setting "Person detection" (toggle on/off, set sensitivity).

This is the first step of controlling the "AI detection feature" Person detection from Home-assistant. 

This feature request seems to be related: https://github.com/JurajNyiri/HomeAssistant-Tapo-Control/issues/204

Edit: Person Detection is included with 3MP/4MP cameras