### PR TITLE
Add windows support for downloading recordings

### DIFF
--- a/pytapo/media_stream/convert.py
+++ b/pytapo/media_stream/convert.py
@@ -30,11 +30,12 @@ class Convert:
             file.write(self.audioWriter.getvalue())
             file.close()
 
-            cmd = 'ffmpeg -ss 00:00:00 -i "{inputVideoFile}" -f alaw -ar 8000 -i "{inputAudioFile}" -t {videoLength} -y -c:v copy -c:a aac -map 0:v:0 -map 1:a:0 "{outputFile}" >/dev/null 2>&1'.format(
+            cmd = 'ffmpeg -ss 00:00:00 -i "{inputVideoFile}" -f alaw -ar 8000 -i "{inputAudioFile}" -t {videoLength} -y -c:v copy -c:a aac -map 0:v:0 -map 1:a:0 "{outputFile}" >{devnull} 2>&1'.format(
                 inputVideoFile=tempVideoFileLocation,
                 inputAudioFile=tempAudioFileLocation,
                 outputFile=fileLocation,
                 videoLength=str(datetime.timedelta(seconds=fileLength)),
+                devnull=os.devnull
             )
             os.system(cmd)
 

--- a/pytapo/media_stream/convert.py
+++ b/pytapo/media_stream/convert.py
@@ -59,7 +59,7 @@ class Convert:
     def calculateLength(self):
         detectedLength = False
         try:
-            with tempfile.NamedTemporaryFile() as tmp:
+            with tempfile.NamedTemporaryFile(delete=False) as tmp:
                 tmp.write(self.writer.getvalue())
                 result = subprocess.run(
                     [
@@ -78,7 +78,7 @@ class Convert:
                 detectedLength = float(result.stdout)
                 self.known_lengths[self.addedChunks] = detectedLength
                 self.lengthLastCalculatedAtChunk = self.addedChunks
-                tmp.close()
+            os.unlink(tmp.name)
         except Exception as e:
             print("")
             print(e)


### PR DESCRIPTION
Hello:

This fixes #50 . 

1. The first commit changes the hardcoded `/dev/null` device to `os.devnull` which fixes redirection in Windows when saving the file. 
2. The second commit is a workaround for Windows, `tempfile.NamedTemporaryFile` works weird on Windows, when writing the contents, those are not flushed (even with `flush()`) so disabling the manually deleting of file and doing it manually works correctly (and should continue to work under other OS) - I also removed the `close()` call as using `with` that's unnecessary.