### PR TITLE
Update __init__.py

### DIFF
--- a/pytapo/__init__.py
+++ b/pytapo/__init__.py
@@ -254,7 +254,7 @@ class Tapo:
                         "channel": 0,
                         "start_time": startTime,
                         "end_time": endTime,
-                        "end_index": 99,
+                        "end_index": 999,
                     }
                 }
             },

--- a/pytapo/__init__.py
+++ b/pytapo/__init__.py
@@ -236,7 +236,7 @@ class Tapo:
 
     def getEvents(self, startTime=False, endTime=False):
         timeCorrection = self.getTimeCorrection()
-        if not timeCorrection:
+        if timeCorrection is False:
             raise Exception("Failed to get correct camera time.")
 
         nowTS = int(datetime.timestamp(datetime.now()))


### PR DESCRIPTION
In line 238, self.getTimeCorrection might return 0 when nowTS and currentTime["system"]["clock_status"]["seconds_from_1970"] are exactly same.

If timeCorrection is 0, 'not timeCorreciton' is evaluated to True. Line 239 should compare timeCorrection and False.