### PR TITLE
Fix: KeyError in handling 'getPresetConfig'

### DIFF
--- a/pytapo/__init__.py
+++ b/pytapo/__init__.py
@@ -1760,6 +1760,6 @@ class Tapo:
                 else:  # some cameras are not returning method for error messages
                     returnData[requestData["params"]["requests"][i]["method"]] = False
             i += 1
-        if returnData["getPresetConfig"]:
+        if "getPresetConfig" in returnData:
             self.presets = self.processPresetsResponse(returnData["getPresetConfig"])
         return returnData


### PR DESCRIPTION
This will fix issue with C420 cameras where getPresetConfig is not present.

Fixes: https://github.com/JurajNyiri/HomeAssistant-Tapo-Control/issues/455