### PR TITLE
Added condition when downloading record for notification with stream_status finished

### DIFF
--- a/pytapo/media_stream/downloader.py
+++ b/pytapo/media_stream/downloader.py
@@ -6,9 +6,6 @@ from json import JSONDecodeError
 import json
 import os
 import hashlib
-import logging
-
-logger = logging.getLogger(__name__)
 
 class Downloader:
     FRESH_RECORDING_TIME_SECONDS = 60
@@ -199,7 +196,7 @@ class Downloader:
                                     downloading = False
                                     break
                             except JSONDecodeError:
-                                logger.warning("Unable to parse JSON sent from device")
+                                self.tapo.debugLog("Unable to parse JSON sent from device")
                     if downloading:
                         # Handle case where camera randomly stopped respoding
                         if not downloadedFull and not retry:

--- a/pytapo/media_stream/downloader.py
+++ b/pytapo/media_stream/downloader.py
@@ -1,11 +1,14 @@
 from pytapo.media_stream.convert import Convert
 from pytapo import Tapo
 from datetime import datetime
+from json import JSONDecodeError
 
 import json
 import os
 import hashlib
+import logging
 
+logger = logging.getLogger(__name__)
 
 class Downloader:
     FRESH_RECORDING_TIME_SECONDS = 60
@@ -180,7 +183,7 @@ class Downloader:
                                 if ("type" in json_data
                                     and json_data["type"] == "notification"
                                     and "params" in json_data
-                                    and "event_type" in json["params"]
+                                    and "event_type" in json_data["params"]
                                     and json_data["params"]["event_type"] == "stream_status"
                                     and "status" in json_data["params"]
                                     and json_data["params"]["status"] == "finished"):

--- a/pytapo/media_stream/downloader.py
+++ b/pytapo/media_stream/downloader.py
@@ -172,6 +172,31 @@ class Downloader:
                                 convert.save(fileName, segmentLength)
                                 downloading = False
                                 break
+                        # in case a finished stream notification is caught, save the chunks as is
+                        elif resp.mimetype == "application/json":
+                            try:
+                                json_data = json.loads(resp.plaintext.decode())
+
+                                if ("type" in json_data
+                                    and json_data["type"] == "notification"
+                                    and "params" in json_data
+                                    and "event_type" in json["params"]
+                                    and json_data["params"]["event_type"] == "stream_status"
+                                    and "status" in json_data["params"]
+                                    and json_data["params"]["status"] == "finished"):
+                                    downloadedFull = True
+                                    currentAction = "Converting"
+                                    yield {
+                                        "currentAction": currentAction,
+                                        "fileName": fileName,
+                                        "progress": 0,
+                                        "total": 0,
+                                    }
+                                    convert.save(fileName, convert.getLength())
+                                    downloading = False
+                                    break
+                            except JSONDecodeError:
+                                logger.warning("Unable to parse JSON sent from device")
                     if downloading:
                         # Handle case where camera randomly stopped respoding
                         if not downloadedFull and not retry:

--- a/pytapo/media_stream/session.py
+++ b/pytapo/media_stream/session.py
@@ -307,7 +307,7 @@ class HttpMediaSession:
                     elif ("type" in json_data 
                         and json_data["type"] == "notification"
                         and "params" in json_data
-                        and "event_type" in json["params"]
+                        and "event_type" in json_data["params"]
                         and json_data["params"]["event_type"] == "stream_status"
                         and "status" in json_data["params"]
                         and json_data["params"]["status"] == "finished"

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps =
     requests
     urllib3
     pycryptodome
+    rtp
 commands = 
     pytest --ignore=pytapo/media_stream --cov=pytapo --cov-report html --cov-report term
     coverage report --fail-under=100


### PR DESCRIPTION
Closes https://github.com/JurajNyiri/HomeAssistant-Tapo-Control/issues/523

During the download of a record, the camera is sending a json response, notifying that the download finished.

Since the code is not ready for this notification, it never assumed a complete record, entering in a loop between retrying and downloading the same record.

This code prevents the situation, expecting to find the json response, and if such situation occurs, assumes that the download is finished.

For reference, the response to find is the following:

`b'{"type":"notification", "params":{"event_type":"stream_status", "status":"finished"}}'`

Also added missing dependency rtp for tox.