### PR TITLE
Added a check to make sure ffmpeg is installed before processing media streams

### DIFF
--- a/pytapo/media_stream/convert.py
+++ b/pytapo/media_stream/convert.py
@@ -17,6 +17,8 @@ class Convert:
         self.known_lengths = {}
         self.addedChunks = 0
         self.lengthLastCalculatedAtChunk = 0
+        if not self.is_ffmpeg_installed():
+            raise Exception('ffmpeg is not installed')
 
     # cuts and saves the video
     def save(self, fileLocation, fileLength, method="ffmpeg"):
@@ -114,3 +116,10 @@ class Convert:
     def write(self, data: bytes, audioData: bytes):
         self.addedChunks += 1
         return self.writer.write(data) and self.audioWriter.write(audioData)
+    
+    def is_ffmpeg_installed(self):
+        try:
+            subprocess.run(["ffmpeg", "-version"], capture_output=True, check=True)
+            return True
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            return False


### PR DESCRIPTION
I was getting a quite annoying error inside an infinite loop about `ffprobe`. I am not very familiar with `ffmpeg` tool, so it took me a couple of hours to realize that I didn't have `ffmpeg` on my laptop. This check should clarify the problem before trying to parse media stream.

```
...
Downloading ./videos/2024-05-13 05_03_30-2024-05-13 05_04_46.mp4...
[Errno 2] No such file or directory: 'ffprobe'
Warning: Could not calculate length from stream.
Downloading ./videos/2024-05-13 05_03_30-2024-05-13 05_04_46.mp4...
[Errno 2] No such file or directory: 'ffprobe'
Warning: Could not calculate length from stream.
Downloading ./videos/2024-05-13 05_03_30-2024-05-13 05_04_46.mp4...
[Errno 2] No such file or directory: 'ffprobe'
Warning: Could not calculate length from stream.
...
```

It will return the following error with this check if `ffmpeg` is not installed:
```
Traceback (most recent call last):
...
  File "/Users/.../pytapo/media_stream/downloader.py", line 110, in download
    convert = Convert()
              ^^^^^^^^^
  File "/Users/.../pytapo/media_stream/convert.py", line 21, in __init__
    raise Exception('ffmpeg is not installed')
Exception: ffmpeg is not installed
```