### PR TITLE
Quick Response implementation

### DIFF
--- a/pytapo/__init__.py
+++ b/pytapo/__init__.py
@@ -1905,6 +1905,15 @@ class Tapo:
         except Exception:
             raise Exception("No new firmware available.")
 
+    def playQuickResponse(self, id):
+        try:
+            self.performRequest({
+                "method": "playQuickResp",
+                "params": {"quick_response": {"play_quick_resp_audio": {"id": id, "force": "force"}}},
+            })
+        except Exception as e:
+            raise Exception("Quick response with id {} not found or not supported.".format(id))
+
     # Used for purposes of HomeAssistant-Tapo-Control
     # Uses method names from https://md.depau.eu/s/r1Ys_oWoP
     def getMost(self, omit_methods=[]):

--- a/pytapo/__init__.py
+++ b/pytapo/__init__.py
@@ -1907,7 +1907,7 @@ class Tapo:
 
     def playQuickResponse(self, id):
         try:
-            self.performRequest({
+            return self.performRequest({
                 "method": "playQuickResp",
                 "params": {"quick_response": {"play_quick_resp_audio": {"id": id, "force": "force"}}},
             })

--- a/pytapo/__init__.py
+++ b/pytapo/__init__.py
@@ -1906,13 +1906,10 @@ class Tapo:
             raise Exception("No new firmware available.")
 
     def playQuickResponse(self, id):
-        try:
-            return self.executeFunction(
-                "playQuickResp",
-                {"quick_response": {"play_quick_resp_audio": {"id": id, "force": "force"}}},
-            )
-        except Exception as e:
-            raise Exception("Quick response with id {} not found or not supported.".format(id))
+        return self.executeFunction(
+            "playQuickResp",
+            {"quick_response": {"play_quick_resp_audio": {"id": id, "force": "force"}}},
+        )
 
     def getQuickResponseList(self):
         return self.executeFunction(

--- a/pytapo/__init__.py
+++ b/pytapo/__init__.py
@@ -1907,18 +1907,18 @@ class Tapo:
 
     def playQuickResponse(self, id):
         try:
-            return self.performRequest({
-                "method": "playQuickResp",
-                "params": {"quick_response": {"play_quick_resp_audio": {"id": id, "force": "force"}}},
-            })
+            return self.executeFunction(
+                "playQuickResp",
+                {"quick_response": {"play_quick_resp_audio": {"id": id, "force": "force"}}},
+            )
         except Exception as e:
             raise Exception("Quick response with id {} not found or not supported.".format(id))
 
     def getQuickResponseList(self):
-        return self.performRequest({
-            "method": "getQuickRespList",
-            "params": {"quick_response": {}},
-        })
+        return self.executeFunction(
+            "getQuickRespList",
+            {"quick_response": {}},
+        )
 
     # Used for purposes of HomeAssistant-Tapo-Control
     # Uses method names from https://md.depau.eu/s/r1Ys_oWoP

--- a/pytapo/__init__.py
+++ b/pytapo/__init__.py
@@ -2122,6 +2122,10 @@ class Tapo:
                         "method": "getVideoCapability",
                         "params": {"video_capability": {"name": "main"}},
                     },
+                    {
+                        "method": "getQuickRespList",
+                        "params": {"quick_response": {}},
+                    },
                 ]
             },
         }

--- a/pytapo/__init__.py
+++ b/pytapo/__init__.py
@@ -1914,6 +1914,12 @@ class Tapo:
         except Exception as e:
             raise Exception("Quick response with id {} not found or not supported.".format(id))
 
+    def getQuickResponseList(self):
+        return self.performRequest({
+            "method": "getQuickRespList",
+            "params": {"quick_response": {}},
+        })
+
     # Used for purposes of HomeAssistant-Tapo-Control
     # Uses method names from https://md.depau.eu/s/r1Ys_oWoP
     def getMost(self, omit_methods=[]):

--- a/pytapo/const.py
+++ b/pytapo/const.py
@@ -11,6 +11,7 @@ ERROR_CODES = {
     "-40209": "Invalid login credentials",
     "-64304": "Maximum Pan/Tilt range reached",
     "-71103": "User ID is not authorized",
+    "72102": "Quick response id not found",
 }
 MAX_LOGIN_RETRIES = 2
 


### PR DESCRIPTION
Certain devices, such as the D230, support playing pre-recorded audio files, which can be configured for each device via the Tapo app.

A call of  `getMost()` allows retrieval of all available audio files. Using a file’s ID, the method `playQuickResponse(id)`  can be used to initiate playback.

Default output of `getMost()` on a D230 in German:
```json
{
  "method": "getQuickRespList",
  "result": {
    "quick_response": {
      "quick_resp_audio": [
        {
          "file_1": {
            "id": "13056",
            "name": "Hallo, es kann gerade niemand an die Tür gehen. Wir sind informiert, dass Sie da waren.",
            "index": "1",
            "duration": "5872",
            "read_only": "1"
          }
        },
        {
          "file_2": {
            "id": "13057",
            "name": "Hallo, bitte legen Sie den Gegenstand vor die Tür.",
            "index": "2",
            "duration": "3722",
            "read_only": "1"
          }
        },
        {
          "file_3": {
            "id": "13058",
            "name": "Ich bin in einer Minute da.",
            "index": "3",
            "duration": "1600",
            "read_only": "1"
          }
        },
        {
          "file_4": {
            "id": "13059",
            "name": "Tut mir leid, kein Interesse.",
            "index": "4",
            "duration": "2349",
            "read_only": "1"
          }
        },
        {
          "file_5": {
            "id": "13060",
            "name": "Sie sind unbefugt eingedrungen. Wir haben die Polizei gerufen.",
            "index": "5",
            "duration": "4319",
            "read_only": "1"
          }
        }
      ]
    }
  },
  "error_code": 0
}
```
If the function is not supported by the tapo device the result will be `False`

Example code for playback of the first file:
```python
device.playQuickResponse("13056")
```