### PR TITLE
chore: add python-kasa to dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/JurajNyiri/pytapo",
     packages=setuptools.find_packages(),
-    install_requires=["requests", "urllib3", "pycryptodome", "rtp"],
+    install_requires=["requests", "urllib3", "pycryptodome", "rtp", "python-kasa"],
     tests_require=["pytest", "pytest-asyncio", "mock"],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     urllib3
     pycryptodome
     rtp
+    python-kasa
 commands = 
     pytest --ignore=pytapo/media_stream --cov=pytapo --cov-report html --cov-report term
     coverage report --fail-under=100


### PR DESCRIPTION
Since 037c4c81bacddbc4ecbc5f2eafba75d857be05df pytapo now appears to depend on python-kasa, but this was missing from the dependencies list. This commit simply fixes that.