### PR TITLE
JSON encoded record_plan list value should not contains space

### DIFF
--- a/pytapo/__init__.py
+++ b/pytapo/__init__.py
@@ -1441,19 +1441,19 @@ class Tapo:
         recordPlan = {"enabled": "on" if enabled else "off"}
 
         if sunday is not None and type(sunday) is list:
-            recordPlan["sunday"] = json.dumps(sunday)
+            recordPlan["sunday"] = json.dumps(sunday, separators=(',', ':'))
         if monday is not None and type(monday) is list:
-            recordPlan["monday"] = json.dumps(monday)
+            recordPlan["monday"] = json.dumps(monday, separators=(',', ':'))
         if tuesday is not None and type(tuesday) is list:
-            recordPlan["tuesday"] = json.dumps(tuesday)
+            recordPlan["tuesday"] = json.dumps(tuesday, separators=(',', ':'))
         if wednesday is not None and type(wednesday) is list:
-            recordPlan["wednesday"] = json.dumps(wednesday)
+            recordPlan["wednesday"] = json.dumps(wednesday, separators=(',', ':'))
         if thursday is not None and type(thursday) is list:
-            recordPlan["thursday"] = json.dumps(thursday)
+            recordPlan["thursday"] = json.dumps(thursday, separators=(',', ':'))
         if friday is not None and type(friday) is list:
-            recordPlan["friday"] = json.dumps(friday)
+            recordPlan["friday"] = json.dumps(friday, separators=(',', ':'))
         if saturday is not None and type(saturday) is list:
-            recordPlan["saturday"] = json.dumps(saturday)
+            recordPlan["saturday"] = json.dumps(saturday, separators=(',', ':'))
 
         return self.executeFunction(
             "setRecordPlan",


### PR DESCRIPTION
For some reason, when Tapo sees space characters in the record_plan value, it will only take only the first item. This fix will let Tapo to accept all items inside the record plan.

**Example:**
If we send `"sunday": "[\"0000-0900:2\", \"2200-2400:2\"]"`, Tapo would take only the "0000-0900:2" as the record plan for Sunday.
To tell it accept all 2 slots, we will have to send `"sunday": "[\"0000-0900:2\",\"2200-2400:2\"]"` (without the space between 2 items)