### PR TITLE
Handle missing ffprobe duration without stdout spam

### DIFF
--- a/pytapo/media_stream/convert.py
+++ b/pytapo/media_stream/convert.py
@@ -81,32 +81,38 @@ class Convert:
     # calculates real stream length, hard on processing since it has to go through all the frames
     def calculateLength(self):
         detectedLength = False
+        tmp_path = None
         try:
             with tempfile.NamedTemporaryFile(delete=False) as tmp:
+                tmp_path = tmp.name
                 tmp.write(self.writer.getvalue())
-                result = subprocess.run(
-                    [
-                        "ffprobe",
-                        "-v",
-                        "fatal",
-                        "-show_entries",
-                        "format=duration",
-                        "-of",
-                        "default=noprint_wrappers=1:nokey=1",
-                        tmp.name,
-                    ],
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
-                )
-                detectedLength = float(result.stdout)
-                self.known_lengths[self.addedChunks] = detectedLength
-                self.lengthLastCalculatedAtChunk = self.addedChunks
-            os.unlink(tmp.name)
-        except Exception as e:
-            print("")
-            print(e)
-            print("Warning: Could not calculate length from stream.")
-            pass
+
+            result = subprocess.run(
+                [
+                    "ffprobe",
+                    "-v",
+                    "fatal",
+                    "-show_entries",
+                    "format=duration",
+                    "-of",
+                    "default=noprint_wrappers=1:nokey=1",
+                    tmp_path,
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
+            duration_output = result.stdout.decode(errors="ignore").strip()
+            if not duration_output:
+                return False
+
+            detectedLength = float(duration_output)
+            self.known_lengths[self.addedChunks] = detectedLength
+            self.lengthLastCalculatedAtChunk = self.addedChunks
+        except Exception:
+            logger.debug("Could not calculate length from stream", exc_info=True)
+        finally:
+            if tmp_path and os.path.exists(tmp_path):
+                os.unlink(tmp_path)
         return detectedLength
 
     # returns length of video, can return an estimate which is usually very close


### PR DESCRIPTION
## Summary
When `ffprobe` cannot determine a stream duration, `pytapo` currently prints the raw exception and a warning directly to stdout. In Home Assistant setups this can spam logs with repeated messages like:

- `could not convert string to float: b''`
- `Warning: Could not calculate length from stream.`

This patch makes that failure path quieter and more robust.

## Changes
- decode `ffprobe` output safely
- return early when the duration output is empty
- log the exception at debug level instead of printing to stdout
- always clean up the temporary file in a `finally` block

## Why
The existing behavior is non-fatal, but noisy. This keeps the same tolerant behavior while avoiding repeated stdout spam in downstream applications such as Home Assistant integrations that depend on `pytapo`.

## Validation
- `python3 -m py_compile pytapo/media_stream/convert.py`