### PR TITLE
setOsd: fix logo defaults and add coordinate validation

### DIFF
--- a/pytapo/__init__.py
+++ b/pytapo/__init__.py
@@ -529,21 +529,16 @@ class Tapo:
             data["OSD"]["label_info_1"]["enabled"] = "off"
         else:
             data["OSD"]["label_info_1"]["text"] = label
-        if (
-            dateX > 10000
-            or dateX < 0
-            or labelX > 10000
-            or labelX < 0
-            or weekX > 10000
-            or weekX < 0
-            or dateY > 10000
-            or dateY < 0
-            or labelY > 10000
-            or labelY < 0
-            or weekY > 10000
-            or weekY < 0
-        ):
-            raise Exception("Error: Incorrect corrdinates, must be between 0 and 10000")
+        coords = {
+            "dateX": dateX, "dateY": dateY,
+            "labelX": labelX, "labelY": labelY,
+            "weekX": weekX, "weekY": weekY,
+        }
+        for name, val in coords.items():
+            if not 0 <= val <= 10000:
+                raise Exception(
+                    f"Error: {name} is {val}, must be between 0 and 10000"
+                )
 
         return self.performRequest(data)
 

--- a/pytapo/__init__.py
+++ b/pytapo/__init__.py
@@ -487,7 +487,7 @@ class Tapo:
         weekX=0,
         weekY=0,
         logoX=0,
-        logoY=0,
+        logoY=9150,
     ):
         if self.childID:
             raise Exception("setOsd not supported for child devices yet")
@@ -533,6 +533,7 @@ class Tapo:
             "dateX": dateX, "dateY": dateY,
             "labelX": labelX, "labelY": labelY,
             "weekX": weekX, "weekY": weekY,
+            "logoX": logoX, "logoY": logoY,
         }
         for name, val in coords.items():
             if not 0 <= val <= 10000:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pytapo",
-    version="3.4.13",
+    version="3.4.14",
     author="Juraj Nyíri",
     author_email="juraj.nyiri@gmail.com",
     description="Python library for communication with Tapo Cameras",


### PR DESCRIPTION
Hello, here are a few logo-related fixes:

* bump version to 3.4.14
* setOsd: fix logo defaults and add coordinate validation
    
    PR #163 added logo support but defaulted logoY to 0 instead of 9150
    (the factory position, bottom-left). Also validate logo coordinates
    like the other fields.
* setOsd: refactor coordinate validation for readability
    
    Use a loop instead of a giant if/or chain. Also tells you which
    coordinate is wrong now.
