### PR TITLE
Fix tempfile leak in Convert.calculateLength

### DIFF
--- a/pytapo/media_stream/convert.py
+++ b/pytapo/media_stream/convert.py
@@ -81,8 +81,10 @@ class Convert:
     # calculates real stream length, hard on processing since it has to go through all the frames
     def calculateLength(self):
         detectedLength = False
+        tmp_name = None
         try:
             with tempfile.NamedTemporaryFile(delete=False) as tmp:
+                tmp_name = tmp.name
                 tmp.write(self.writer.getvalue())
                 result = subprocess.run(
                     [
@@ -93,7 +95,7 @@ class Convert:
                         "format=duration",
                         "-of",
                         "default=noprint_wrappers=1:nokey=1",
-                        tmp.name,
+                        tmp_name,
                     ],
                     stdout=subprocess.PIPE,
                     stderr=subprocess.STDOUT,
@@ -101,12 +103,16 @@ class Convert:
                 detectedLength = float(result.stdout)
                 self.known_lengths[self.addedChunks] = detectedLength
                 self.lengthLastCalculatedAtChunk = self.addedChunks
-            os.unlink(tmp.name)
         except Exception as e:
             print("")
             print(e)
             print("Warning: Could not calculate length from stream.")
-            pass
+        finally:
+            if tmp_name is not None:
+                try:
+                    os.unlink(tmp_name)
+                except OSError:
+                    pass
         return detectedLength
 
     # returns length of video, can return an estimate which is usually very close


### PR DESCRIPTION
## Summary

`Convert.calculateLength` leaks a file in the system tempdir on every failed
probe. With `tempfile.NamedTemporaryFile(delete=False)` the cleanup is
`os.unlink(tmp.name)` *outside* the `try` block, and the surrounding handler
is a bare `except Exception: pass`. Whenever the body raises (the common
case is `float(result.stdout)` raising `ValueError` because `ffprobe -v fatal`
suppressed diagnostics and produced empty stdout, but the same applies to
any other failure inside the `with`), the unlink is never reached and the
tempfile is orphaned.

In a long-running consumer this accumulates fast. Caught it in the wild on
a Home Assistant install (via `tapo_control`): ~5.9 M leaked files, ~400 GB
in `/var/tmp/` over a few weeks, eventually ENOSPC'd the host disk and took
out unrelated services.

## Fix

- Capture `tmp.name` into a local up-front so we always know the path.
- Move the unlink into a `finally` block and ignore `OSError` (handles the
  rare case where the file is already gone).
- Drop the redundant `pass` after the print statements.

Behaviour on the success path is unchanged.

## Test plan

- [x] Existing success path: `calculateLength` still returns `detectedLength`
      and the tempfile is removed.
- [x] Forced-failure path (mocked `ffprobe` returning empty stdout): the
      function now returns `False` *and* the tempfile is removed.