### PR TITLE
Fix SSLEOFError UNEXPECTED_EOF_WHILE_READING on Python 3.12+ (Tapo cameras)

### DIFF
--- a/pytapo/transport/kasa/kasa.py
+++ b/pytapo/transport/kasa/kasa.py
@@ -423,6 +423,10 @@ class Kasa:
             context.set_ciphers(SslAesTransport.CIPHERS)
         context.check_hostname = False
         context.verify_mode = ssl.CERT_NONE
+        with suppress(Exception):
+            # Tapo cameras do not properly close TLS connections; suppress the
+            # resulting EOF error introduced in Python 3.12 (ssl.OP_IGNORE_UNEXPECTED_EOF).
+            context.options |= ssl.OP_IGNORE_UNEXPECTED_EOF
         return context
 
     def _get_kasa_default_ssl_context(self):
@@ -439,6 +443,8 @@ class Kasa:
             context.minimum_version = ssl.TLSVersion.TLSv1
         with suppress(Exception):
             context.options |= ssl.OP_LEGACY_SERVER_CONNECT
+        with suppress(Exception):
+            context.options |= ssl.OP_IGNORE_UNEXPECTED_EOF
         with suppress(Exception):
             context.set_ciphers("ALL:@SECLEVEL=0")
         return context

--- a/pytapo/transport/pytapo/TlsAdapter.py
+++ b/pytapo/transport/pytapo/TlsAdapter.py
@@ -1,4 +1,5 @@
 import ssl
+from contextlib import suppress
 
 from requests.adapters import HTTPAdapter
 import urllib3
@@ -14,8 +15,14 @@ class TlsAdapter(HTTPAdapter):
         super(TlsAdapter, self).__init__(**kwargs)
 
     def init_poolmanager(self, connections, maxsize, **pool_kwargs):
+        options = self.ssl_options
+        with suppress(AttributeError):
+            # OP_IGNORE_UNEXPECTED_EOF added in Python 3.12; Tapo cameras do not
+            # properly close TLS connections which raises SSLEOFError on newer Python.
+            options |= ssl.OP_IGNORE_UNEXPECTED_EOF
+
         ctx = ssl_.create_urllib3_context(
-            cert_reqs=ssl.CERT_NONE, options=self.ssl_options
+            cert_reqs=ssl.CERT_NONE, options=options
         )
 
         ctx.set_ciphers("ALL:@SECLEVEL=0")

--- a/pytapo/transport/pytapo/pytapo.py
+++ b/pytapo/transport/pytapo/pytapo.py
@@ -326,6 +326,8 @@ class pyTapo:
             "remote end closed connection without response",
             "connection aborted",
             "remotedisconnected",
+            "unexpected_eof_while_reading",  # Python 3.12+ SSL EOF on Tapo cameras
+            "eof occurred in violation of protocol",
         )
         return any(marker in err_str for marker in transient_markers)
 


### PR DESCRIPTION
## Problem

Since Python 3.12, OpenSSL enforces strict TLS connection teardown: a connection closed by the peer without sending a `close_notify` alert now raises `SSLEOFError: UNEXPECTED_EOF_WHILE_READING` instead of being silently accepted.

Tapo cameras consistently close their TCP connections without sending `close_notify`. This means **every single request** to a camera fails with an SSL error on Python 3.12+, making pytapo entirely non-functional on recent Python environments (tested on Python 3.12, 3.13, 3.14).

Typical errors seen in Home Assistant logs:
```
SSLEOFError: EOF occurred in violation of protocol (_ssl.c:...)
ssl.SSLEOFError: UNEXPECTED_EOF_WHILE_READING
```

## Root cause

Python 3.12 introduced `ssl.OP_IGNORE_UNEXPECTED_EOF` (see [bpo-44856](https://bugs.python.org/issue44856) and [Python docs](https://docs.python.org/3/library/ssl.html#ssl.OP_IGNORE_UNEXPECTED_EOF)), which instructs OpenSSL to treat an abrupt EOF as a clean close rather than a protocol violation. This flag is the standard mitigation for devices that do not properly implement TLS teardown.

## Changes

### 1. `pytapo/transport/kasa/kasa.py` — KLAP / aiohttp transport

`OP_IGNORE_UNEXPECTED_EOF` is added to both SSL contexts used by the kasa transport:
- `_create_kasa_default_ssl_context` (used by KLAP-capable cameras)
- `_create_kasa_unsecure_ssl_context` (legacy fallback)

Both additions are wrapped in `with suppress(Exception)` for full backward compatibility with Python < 3.12, where the constant does not exist.

### 2. `pytapo/transport/pytapo/TlsAdapter.py` — stok / requests+urllib3 transport

Same fix for the legacy stok authentication transport, which uses `requests` + urllib3 instead of aiohttp. `OP_IGNORE_UNEXPECTED_EOF` is OR'd into the options passed to `ssl_.create_urllib3_context`.

Wrapped in `with suppress(AttributeError)` for Python < 3.12 compatibility.

### 3. `pytapo/transport/pytapo/pytapo.py` — transient error retry

In rare cases, an EOF occurs mid-response (not at TLS teardown), where `OP_IGNORE_UNEXPECTED_EOF` cannot help. The error surfaces as an exception whose message contains `UNEXPECTED_EOF_WHILE_READING` or `EOF occurred in violation of protocol`.

Two markers are added to `_isTransientConnectionReset` so pytapo retries the request automatically rather than propagating the exception to the caller.

## Backward compatibility

- All changes are no-ops on Python < 3.12: the `suppress()` wrappers silently skip setting the flag when it does not exist.
- No behaviour change for cameras that correctly send `close_notify`.
- No new dependencies.

## Testing

Tested on:
- Home Assistant 2026.6 / Python 3.14
- Tapo C220 (indoor, stok auth)
- Tapo C325WB (outdoor, KLAP auth)

Before this fix: SSL errors on every camera poll, integration non-functional.
After this fix: no SSL errors, stable operation over multiple days.